### PR TITLE
Fix previous text change

### DIFF
--- a/Documentation/Instruction Set.txt
+++ b/Documentation/Instruction Set.txt
@@ -1,4 +1,4 @@
-Rubbish Instruction Set, Compiler Meta-commands, and Pointers x
+Rubbish Instruction Set, Compiler Meta-commands, and Pointers
 --------------------------------------------------------------
 
 About labels


### PR DESCRIPTION
A previous text change was made to instruction set.txt to test development branch protections.

This pull request is to change those back.